### PR TITLE
small int + workaround for credentials

### DIFF
--- a/connectors/java/databasetable/src/main/java/org/identityconnectors/databasetable/DatabaseTableConfiguration.java
+++ b/connectors/java/databasetable/src/main/java/org/identityconnectors/databasetable/DatabaseTableConfiguration.java
@@ -872,4 +872,23 @@ public class DatabaseTableConfiguration extends AbstractConfiguration {
             return getMessage(key);
         }
     }
+
+    private boolean ignorePasswordWorkaround = false;
+
+    /**
+     * If set to true then the password processed in updateOp. It will simply be ignored.
+     * If set to false then the password will be processed as usual.
+     */
+    @ConfigurationProperty(order = 25,
+            displayMessageKey = "IGNORE_PASSWORD_WORKAROUND_DISPLAY",
+            helpMessageKey = "IGNORE_PASSWORD_WORKAROUND_HELP")
+    public boolean getIgnorePasswordWorkaround() {
+        return ignorePasswordWorkaround;
+    }
+
+    public void setIgnorePasswordWorkaround(boolean ignorePasswordWorkaround) {
+        this.ignorePasswordWorkaround = ignorePasswordWorkaround;
+    }
+
+
 }

--- a/connectors/java/databasetable/src/main/resources/org/identityconnectors/databasetable/Messages.properties
+++ b/connectors/java/databasetable/src/main/resources/org/identityconnectors/databasetable/Messages.properties
@@ -119,3 +119,5 @@ SQL_STATE_INVALID_ATTRIBUTE_VALUE_DISPLAY=Invalid Attribute Value SQL state code
 SQL_STATE_INVALID_ATTRIBUTE_VALUE_HELP=Collection of values representing SQL state codes which can be interpreted to create an Invalid Attribute Value exception.
 SQL_STATE_CONFIGURATION_EXCEPTION_DISPLAY=Configuration Exception SQL state codes
 SQL_STATE_CONFIGURATION_EXCEPTION_HELP=Collection of values representing SQL state codes which can be interpreted to create an Configuration exception.
+IGNORE_PASSWORD_WORKAROUND_DISPLAY=Ignore Password Workaround
+IGNORE_PASSWORD_WORKAROUND_HELP=If set to true then the password processed in updateOp. It will simply be ignored. If set to false then the password will be processed as usual.


### PR DESCRIPTION
We would like to contribute 2 minor changes:
- fix for small ints to be interpreted as int
- workaround for credentials reset within self service, now you can with configuration property disable this options when you are not using password propagation on specific resource, which will omit the error